### PR TITLE
Commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.7
+    hooks:
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
     rev: v0.11.7
     hooks:
       - id: ruff
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]

--- a/README.md
+++ b/README.md
@@ -71,3 +71,20 @@ uncoil -d . \
 -x .git,.gitignore,LICENSE,.venv,.ruff_cache,__pycache__,.pytest_cache,examples \
 -t uncoil_codebase
 ```
+## Development
+To develop the package further:
+
+1. Clone the repository and create a branch
+2. Install with dev dependencies:
+```bash
+pip install -e ".[dev]"
+```
+3. Install pre-commit hook
+```bash
+pre-commit install
+pre-commit autoupdate # optionally update
+```
+4. Run tests:
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 dev = [
     "pytest",
     "ruff",
+    "pre-commit",
 ]
 
 [project.scripts]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,20 +1,14 @@
-import os
 import sys
 import pytest
-import tempfile
 from unittest import mock
-from pathlib import Path
-from io import StringIO
 
 from src.uncoil.__main__ import (
     matches_skip_pattern,
     unfurl_directory,
-    create_tree,
     print_file_contents,
     main
 )
 
-from rich.tree import Tree
 
 @pytest.fixture
 def sample_directory(tmp_path):
@@ -54,11 +48,11 @@ def test_matches_skip_pattern():
     """
     Test the matches_skip_pattern function.
     """
-    assert matches_skip_pattern("src/uncoil/__init__.py", [".git", ".pyc"]) == False
-    assert matches_skip_pattern(".git/config", [".git", ".pyc"]) == True
-    assert matches_skip_pattern("src/uncoil/__pycache__/file.pyc", [".git", ".pyc"]) == True
-    assert matches_skip_pattern("README.md", []) == False
-    assert matches_skip_pattern("README.md", ["README"]) == True
+    assert matches_skip_pattern(".git/config", [".git", ".pyc"])
+    assert matches_skip_pattern("src/uncoil/__pycache__/file.pyc", [".git", ".pyc"])
+    assert matches_skip_pattern("README.md", ["README"])
+    assert not matches_skip_pattern("src/uncoil/__init__.py", [".git", ".pyc"])
+    assert not matches_skip_pattern("README.md", [])
 
 def test_unfurl_directory(sample_directory):
     """
@@ -83,8 +77,7 @@ def test_print_file_contents(sample_directory, capsys):
     """
     Test the print_file_contents function.
     """
-    # Capture the console output
-    captured_output = StringIO()
+
     console = mock.Mock()
     
     file_path = sample_directory / "README.md"
@@ -92,7 +85,7 @@ def test_print_file_contents(sample_directory, capsys):
     
     # Assert that console.print was called with the correct content
     console.print.assert_any_call(f"==> {file_path} <==")
-    console.print.assert_any_call("# Sample README")
+    console.print.assert_any_call("# Sample README", markup=False)
     console.print.assert_any_call("\n")
 
 def test_main_with_tags(sample_directory, tmp_path):
@@ -179,7 +172,7 @@ def test_main_missing_required_argument(tmp_path, capsys):
     ]
     
     with mock.patch.object(sys, 'argv', args):
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(SystemExit):
             main()
     
     # Capture the stderr output


### PR DESCRIPTION
- incorporate commit hooks into development workflow
- enforce default linting with `ruff` (applied in this PR`
- protect local main branch from commits, enhancing enforcement of remote main branch protection